### PR TITLE
Add NestJS

### DIFF
--- a/packages/stateofjs/lib/modules/outline.js
+++ b/packages/stateofjs/lib/modules/outline.js
@@ -148,6 +148,7 @@ export const outline = [
     id: 'backend',
     questions: [
       'Express',
+      'NestJS',
       'Next.js',
       'Koa',
       'Meteor',

--- a/packages/stateofjs/lib/modules/outline.yml
+++ b/packages/stateofjs/lib/modules/outline.yml
@@ -126,6 +126,7 @@
   id: backend
   questions:
     - Express
+    - NestJS
     - Next.js
     - Koa
     - Meteor


### PR DESCRIPTION
I added NestJS to backend framework options. 

It's actually one of the most popular node.js frameworks at the moment.

Below Google Trends screenshot, for a reference.

![image](https://user-images.githubusercontent.com/1279430/69620384-98278e00-103d-11ea-8c6f-2b799f2a3a8e.png)
