### PR TITLE
Adjust check input position

### DIFF
--- a/packages/stateofjs/lib/stylesheets/_forms.scss
+++ b/packages/stateofjs/lib/stylesheets/_forms.scss
@@ -50,7 +50,6 @@
   .form-check-input {
     margin: 0px $spacing/1.5 0 0;
     position: relative;
-    top: -3px;
     display: block;
   }
   .form-check-label {


### PR DESCRIPTION
We slightly lower the check input below so that it is almost on the label baseline. As result, it looks nicer and neater.

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/96353737-8d536d00-10d7-11eb-9c6e-663c566fb9a1.png) | ![image](https://user-images.githubusercontent.com/4408379/96353750-a9570e80-10d7-11eb-8030-981111f0ba09.png) |

