### PR TITLE
Fix path for OG image

### DIFF
--- a/packages/stateofjs/lib/components/survey/SurveyHeadTags.jsx
+++ b/packages/stateofjs/lib/components/survey/SurveyHeadTags.jsx
@@ -3,7 +3,7 @@ import { Components } from 'meteor/vulcan:core';
 
 const SurveyHeadTags = ({ survey }) => {
   const { name, year, imageUrl } = survey;
-  return <Components.HeadTags title={`${name} ${year}`} image={imageUrl} />;
+  return <Components.HeadTags title={`${name} ${year}`} image={`/surveys/${imageUrl}`} />;
 };
 
 export default SurveyHeadTags;


### PR DESCRIPTION
Currently, we have wrong image path for OG:

```html
<meta data-react-helmet="true" property="og:image" content="https://survey.stateofjs.com/stateofcss2020.png">
```

Need to be like that: https://survey.stateofjs.com/stateofcss2020.png -> https://survey.stateofjs.com/surveys/stateofcss2020.png