### PR TITLE
Fix typos and add missing tranlations.

### DIFF
--- a/packages/stateofjs/lib/i18n/common/yml/en-US.yml
+++ b/packages/stateofjs/lib/i18n/common/yml/en-US.yml
@@ -1,6 +1,6 @@
 locale: en-US
 translations:
-  
+
   ###########################################################################
   # General
   ###########################################################################
@@ -15,16 +15,16 @@ translations:
       - Avoid duplicate responses
 
       - Give you access to your data
-      
+
       - Save your session as you go
-      
+
       - Notify you when results are live
   - key: general.survey_closed
     t: >
       Sorry, the survey is now closed! You can still review your data but you won't be able to modify it.
   - key: general.survey_read_only
     t: >
-      You are currently viewing this survey in read-only mode. 
+      You are currently viewing this survey in read-only mode.
   - key: general.survey_read_only_back
     t: >
       <a href="{link}">Go back</a> to the main survey page to start or resume a session.
@@ -62,7 +62,7 @@ translations:
     t: Questions? Found a bug? <a href="{link}" target="_blank">Leave an issue</a>.
   - key: general.emoji_icons
     t: Emoji icons by <a target="_blank" rel="noreferrer" href="https://icons8.com">Icons8</a>
-    
+
   # navigation
   - key: general.table_of_contents
     t: Table of Contents
@@ -71,14 +71,14 @@ translations:
       Note: all questions are optional, reaching 100% completion is not required.
   - key: general.data_is_saved
     t: Your data is saved whenever you navigate to the previous or next section.
-  
+
   # thanks
   - key: general.back
     t: Back
   - key: general.thanks
     t: >
       Thanks for filling out the survey!
-      
+
       Your data is saved. You can review or modify it until the survey closes.
 
       Also, you can help us get the word out by sharing this survey. Every bit counts, and it'll help make our data even
@@ -92,11 +92,10 @@ translations:
     t: >
       This year's {surveyName} survey is now open! {link}
 
-  
   ###########################################################################
   # Nav
   ###########################################################################
-  
+
   - key: nav.surveys
     t: Surveys
   - key: nav.account
@@ -130,7 +129,7 @@ translations:
       If you have any questions about how we use your data, or would like
       us to remove your data from our records,
       please <a href="mailto:hello@stateofjs.com">get in touch</a>.
-      
+
   ###########################################################################
   # Sections
   ###########################################################################
@@ -210,7 +209,7 @@ translations:
     t: Would use again
   - key: options.tools.would_not_use.short
     t: Would not use
-  
+
   # happiness
   - key: options.happiness.very_unhappy
     t: Very Unhappy
@@ -234,7 +233,7 @@ translations:
     t: Agree
   - key: options.opinions.agree_strongly
     t: Agree Strongly
-    
+
   # years of experience
   - key: options.years_of_experience.range_less_than_1
     t: Less than one year
@@ -256,7 +255,7 @@ translations:
     t: 1-2
   - key: options.years_of_experience.range_2_5.short
     t: 2-5
-  - key: options.years_of_experience.range_5_10
+  - key: options.years_of_experience.range_5_10.short
     t: 5-10
   - key: options.years_of_experience.range_10_20.short
     t: 10-20
@@ -562,9 +561,9 @@ translations:
   - key: tools_other.non_js_languages.others.description
     t: Other answers (freeform field).
 
-###########################################################################
-# Resources
-###########################################################################
+  ###########################################################################
+  # Resources
+  ###########################################################################
 
   # blogs & magazines
   - key: resources.blogs_news_magazines

--- a/packages/stateofjs/lib/i18n/common/yml/es-ES.yml
+++ b/packages/stateofjs/lib/i18n/common/yml/es-ES.yml
@@ -1,6 +1,6 @@
 locale: es-ES
 translations:
-  
+
   ###########################################################################
   # General
   ###########################################################################
@@ -15,9 +15,9 @@ translations:
       - Evitar respuestas duplicadas
 
       - Darte acceso a tu información
-      
+
       - Salvar tu sesión según avanzas
-      
+
       - Notificarte cuando tengamos los resultados
   - key: general.survey_closed
     t: >
@@ -62,7 +62,7 @@ translations:
     t: ¿Preguntas? ¿Has encontrado un fallo? <a href="{link}" target="_blank">Déjanos lo que has encontrado</a>.
   - key: general.emoji_icons
     t: Emojis por <a target="_blank" rel="noreferrer" href="https://icons8.com">Icons8</a>
-    
+
   # navigation
   - key: general.table_of_contents
     t: Tabla de Contenidos
@@ -71,14 +71,14 @@ translations:
       Nota: todas las preguntas son opcionales, así que no necesitas responderlas todas.
   - key: general.data_is_saved
     t: Salvamos tus respuestas cada vez que navegas entre secciones.
-  
+
   # thanks
   - key: general.back
     t: Volver
   - key: general.thanks
     t: >
       ¡Gracias por rellenar la encuesta!
-      
+
       Tu información está salvada. Puedes revisarla o modificarla hasta que la encuesta esté cerrada.
 
       También puedes ayudarnos a llegar a todo el mundo compartiendo esta encuesta. Todo ayuda es poca, y así podremos hacer
@@ -92,11 +92,10 @@ translations:
     t: >
       ¡La encuesta {surveyName} de este año, está abierta! {link}
 
-  
   ###########################################################################
   # Nav
   ###########################################################################
-  
+
   - key: nav.surveys
     t: Encuestas
   - key: nav.account
@@ -130,7 +129,7 @@ translations:
       Si tienes alguna pregunta sobre como usamos tus datos, o te gustaría
       que los eliminásemos de nuestros registros,
       por favor, <a href="mailto:hello@stateofjs.com">mándanos un email</a>.
-      
+
   ###########################################################################
   # Sections
   ###########################################################################
@@ -195,9 +194,9 @@ translations:
   - key: options.tools.not_interested
     t: 🚫 He oído hablar de ello > No estoy interesado
   - key: options.tools.would_use
-    t: 👍 Lo uso > Lo volvería a usar
+    t: 👍 Lo he usado > Lo volveré a usar
   - key: options.tools.would_not_use
-    t: 👎 Lo uso > No lo volvería a usar
+    t: 👎 Lo he usado > No lo volveré a usar
 
   # tools experience (short versions)
   - key: options.tools.never_heard.short
@@ -210,7 +209,7 @@ translations:
     t: Lo volvería a usar
   - key: options.tools.would_not_use.short
     t: No lo usaría
-  
+
   # happiness
   - key: options.happiness.very_unhappy
     t: Muy Descontento
@@ -256,7 +255,7 @@ translations:
     t: 1-2
   - key: options.years_of_experience.range_2_5.short
     t: 2-5
-  - key: options.years_of_experience.range_5_10
+  - key: options.years_of_experience.range_5_10.short
     t: 5-10
   - key: options.years_of_experience.range_10_20.short
     t: 10-20
@@ -301,7 +300,7 @@ translations:
 
   # salary
   - key: options.yearly_salary.range_work_for_free
-    t: Trabajo por la cara
+    t: Trabajo gratis
   - key: options.yearly_salary.range_0_10
     t: $0k-$10k
   - key: options.yearly_salary.range_10_30
@@ -413,6 +412,27 @@ translations:
   - key: options.gender.prefer_not_to_say
     t: Prefiero no decirlo
 
+  # Race & Ethnicity
+
+  - key: options.race_ethnicity.white_european
+    t: Blanco o descendiente de Europeos
+  - key: options.race_ethnicity.south_asian
+    t: Asiático del Sur
+  - key: options.race_ethnicity.hispanic_latin
+    t: Hispano o Latino
+  - key: options.race_ethnicity.east_asian
+    t: Asiático del Este
+  - key: options.race_ethnicity.middle_eastern
+    t: De Oriente Medio
+  - key: options.race_ethnicity.black_african
+    t: Negro o descendiente de Africanos
+  - key: options.race_ethnicity.multiracial
+    t: Multiracial
+  - key: options.race_ethnicity.biracial
+    t: Con dos razas
+  - key: options.race_ethnicity.native_american_islander_australian
+    t: Nativo Americano, de las Islas del Pacífico o Indígena Australiano
+
   # Skin Tone
 
   - key: options.skin_tone.0
@@ -451,7 +471,7 @@ translations:
   - key: tools.happiness.description
     t: >
       En una escala de uno (muy insatisfecho) a cinco (muy satisfecho), ¿cómo de satisfecho estás
-      con el estado general de las cosas relacionadas con las opciones expuestas anteriormente?
+      con el estado general de los elementos relacionados con las opciones expuestas anteriormente?
 
   ###########################################################################
   # Demographics (About You/User Info)
@@ -529,54 +549,54 @@ translations:
   # Other Tools
   ###########################################################################
 
-  - key: other_tools.text_editors
+  - key: tools_other.text_editors
     t: Editores de Texto
-  - key: other_tools.text_editors.description
+  - key: tools_other.text_editors.description
     t: ¿Qué editor(es) de texto usas habitualmente?
-  - key: other_tools.text_editors.others
+  - key: tools_other.text_editors.others
     t: Otros Editores de Texto
-  - key: other_tools.text_editors.others.description
+  - key: tools_other.text_editors.others.description
     t: Otras respuestas (campo de texto libre).
 
-  - key: other_tools.utilities
+  - key: tools_other.utilities
     t: Utilidades
-  - key: other_tools.utilities.description
+  - key: tools_other.utilities.description
     t: ¿Qué librerías de utilidades usas habitualmente?
-  - key: other_tools.utilities.others
+  - key: tools_other.utilities.others
     t: Otras Utilidades
-  - key: other_tools.utilities.others.description
+  - key: tools_other.utilities.others.description
     t: Otras respuestas (campo de texto libre).
 
-  - key: other_tools.browsers
+  - key: tools_other.browsers
     t: Navegadores
-  - key: other_tools.browsers.description
+  - key: tools_other.browsers.description
     t: ¿Con qué navegador(es) trabajas principalmente durante el desarrollo inicial?
-  - key: other_tools.browsers.others
+  - key: tools_other.browsers.others
     t: Otros Navegadores
-  - key: other_tools.browsers.others.description
+  - key: tools_other.browsers.others.description
     t: Otras respuestas (campo de texto libre).
 
-  - key: other_tools.build_tools
+  - key: tools_other.build_tools
     t: Herramientas de Construcción
-  - key: other_tools.build_tools.description
+  - key: tools_other.build_tools.description
     t: ¿Qué herramientas de construcción utilizas?
-  - key: other_tools.build_tools.others
+  - key: tools_other.build_tools.others
     t: Otras Herramientas de Construcción
-  - key: other_tools.build_tools.others.description
+  - key: tools_other.build_tools.others.description
     t: Otras respuestas (campo de texto libre).
 
-  - key: other_tools.non_js_languages
+  - key: tools_other.non_js_languages
     t: Otros Lenguajes (no relacionados con JavaScript)
-  - key: other_tools.non_js_languages.description
+  - key: tools_other.non_js_languages.description
     t: ¿Qué otros lenguajes de programación utilizas?
-  - key: other_tools.non_js_languages.others
+  - key: tools_other.non_js_languages.others
     t: Otros Lenguajes
-  - key: other_tools.non_js_languages.others.description
+  - key: tools_other.non_js_languages.others.description
     t: Otras respuestas (campo de texto libre).
 
-###########################################################################
-# Resources
-###########################################################################
+  ###########################################################################
+  # Resources
+  ###########################################################################
 
   # blogs & magazines
   - key: resources.blogs_news_magazines

--- a/packages/stateofjs/lib/i18n/state-of-css/yml/es-ES.yml
+++ b/packages/stateofjs/lib/i18n/state-of-css/yml/es-ES.yml
@@ -10,10 +10,10 @@ translations:
     t: >
       CSS está evolucionando más deprisa que nunca.
 
-      
+
       Flexbox, Grid, Multi-Column… por no hablar del totalmente nuevo paradigma CSS-in-JS.
 
-      
+
       Así que después del éxito de nuestra encuesta anual sobre el Estado de JavaScrip,
       hemos decidido hacer una dentro del mundo de los estilos y los selectores para ayudar
       a identificar las últimas tendencias… y tratar de reducir la creciente "gran brecha del front"!
@@ -26,7 +26,7 @@ translations:
     t: Diseño
   - key: sections.layout.description
     t: Cómo distribuyes los elementos por la pantalla?
-  
+
   - key: sections.shapes_graphics.title
     t: Formas y Gráficos
   - key: sections.shapes_graphics.description
@@ -50,7 +50,7 @@ translations:
   - key: sections.media_queries.title
     t: Media Queries
   - key: sections.media_queries.description
-    t: Formas de adaptar to página a los dispositivos de tus usuarios o sus preferencias.
+    t: Formas de adaptar tu página a los dispositivos de tus usuarios o sus preferencias.
 
   - key: sections.other_features.title
     t: Otras Características
@@ -207,7 +207,7 @@ translations:
     t: Animaciones
   - key: features.perspective
     t: <code>perspective</code>
-  
+
   # media queries
   - key: features.feature_support_queries
     t: Comprobando Características Soportadas (<code>@supports</code>)
@@ -342,7 +342,7 @@ translations:
 
   - key: features.attributes
     t: Atributos
-  
+
   - key: options.attributes.presence
     t: div[foo] (Presencia)
   - key: options.attributes.equality
@@ -370,7 +370,7 @@ translations:
 
   - key: features.interaction
     t: Interacciones
-  
+
   - key: options.interaction.hover
     t: :hover
   - key: options.interaction.active
@@ -421,7 +421,7 @@ translations:
     t: Navegadores
   - key: environments.browsers.description
     t: ¿En qué navegadores haces pruebas?
-  
+
   - key: environments.form_factors
     t: Factor de Forma
   - key: environments.form_factors.description
@@ -443,22 +443,22 @@ translations:
 
   - key: opinions.css_easy_to_learn
     t: CSS es fácil de aprender
-    
+
   - key: opinions.css_evolving_slowly
     t: CSS está evolucionando muy despacio
-    
+
   - key: opinions.utility_classes_to_be_avoided
     t: Clases funcionales (no-semánticas) (.center, .large-text, etc.) deberían ser evitadas
-    
+
   - key: opinions.selector_nesting_to_be_avoided
     t: Anidar selectores (.foo .bar ul li {...}) debería evitarse
-    
+
   - key: opinions.css_is_programming_language
     t: CSS es un lenguaje de programación
-    
+
   - key: opinions.enjoy_writing_css
     t: Disfruto escribiendo CSS
-    
+
   - key: opinions.currently_missing_from_css.others
     t: ¿Qué crees que le falta a CSS?
   - key: opinions.currently_missing_from_css.others.description
@@ -468,9 +468,9 @@ translations:
     t: CSS en una palabra
   - key: opinions.sum_up_one_word_css.description
     t: ¿Cómo resumirías tu opinión de CSS en una palabra?
-    
+
   - key: happiness.state_of_the_web
     t: ¿Cómo de contento estás con el estado general de las tecnologías web?
-  
+
   - key: happiness.state_of_css
     t: ¿Cómo de contento estás con el estado general de CSS?


### PR DESCRIPTION
I have made the survey and I have noted a few things in the Spanish translations.

I have fixed a couple of typos, and remove some extra spaces. I have also fixed a bug with a missing `.short` property and added missing translations for gender. I have seen that you have removed the skin color emojis and added back the classic gender selector.

I have also changed `other_tools` by `tools_other` because the translations were failing.