### PR TITLE
Improve "learn more about" block

### DIFF
--- a/packages/stateofjs/lib/components/common/Score.jsx
+++ b/packages/stateofjs/lib/components/common/Score.jsx
@@ -11,7 +11,7 @@ import { intlShape } from 'meteor/vulcan:i18n';
 
 const Features = ({ unknownFields, entities, limit }) => {
   const fields = take(unknownFields, limit);
-  
+
   return (
     <div className="score-features">
       <h4 className="score-features-heading">
@@ -20,22 +20,27 @@ const Features = ({ unknownFields, entities, limit }) => {
       <div className="score-features-items">
         {fields.map((field, i) => {
           const entity = entities.find((e) => e.id === field.id);
-          return entity && get(entity, 'mdn.url') ? <FeatureItem key={field.id} entity={entity} showComma={i < (fields.length - 1)} /> : null;
-        })}
+          return entity ? <FeatureItem key={field.id} entity={entity} showComma={i < (fields.length - 1)} /> : null;
+        })}.
       </div>
     </div>
   );
 };
 
-const FeatureItem = ({ entity, showComma }) => (
-  <div className="score-feature">
-    <a className="score-feature-name" href={`https://developer.mozilla.org${get(entity, 'mdn.url')}`}>
-      {entity.name}
-    </a>
-    {showComma && ', '}
-    {/* <p className="score-feature-summary" dangerouslySetInnerHTML={{ __html: get(entity, 'mdn.summary') }} /> */}
-  </div>
-);
+const FeatureItem = ({ entity, showComma }) => {
+  const mdnUrl = get(entity, 'mdn.url');
+  const TagName = mdnUrl ? 'a' : 'span'; 
+
+  return (
+    <div className="score-feature">
+      <TagName className="score-feature-name" href={mdnUrl ? `https://developer.mozilla.org${mdnUrl}` : undefined}>
+        {entity.name}
+      </TagName>
+      {showComma && ', '}
+      {/* <p className="score-feature-summary" dangerouslySetInnerHTML={{ __html: get(entity, 'mdn.summary') }} /> */}
+    </div>
+  )
+};
 
 const Score = ({ response, survey }, { intl }) => {
   const containerRef = useRef(null);
@@ -97,7 +102,7 @@ const Score = ({ response, survey }, { intl }) => {
               <FormattedMessage id="thanks.share_on_twitter" />
             </Components.Button>
             </div>
-            <Features unknownFields={unknownFields} limit={10} entities={entities.filter((e) => e.type === 'feature')} />
+            {unknownFields.length > 0 && <Features unknownFields={unknownFields} limit={10} entities={entities.filter((e) => e.type === 'feature')} />}
           </div>
         </div>
       )}

--- a/packages/stateofjs/lib/components/common/Score.jsx
+++ b/packages/stateofjs/lib/components/common/Score.jsx
@@ -27,21 +27,27 @@ const Features = ({ unknownFields, entities, limit }) => {
   );
 };
 
-const FeatureItem = ({ entity, showComma }) => {
+
+const FeatureItem = ({entity, showComma}) => {
   const mdnUrl = get(entity, 'mdn.url');
-  const TagName = mdnUrl ? 'a' : 'span'; 
+  const TagName = mdnUrl ? 'a' : 'span';
 
   return (
     <div className="score-feature">
-      <TagName className="score-feature-name" href={mdnUrl ? `https://developer.mozilla.org${mdnUrl}` : undefined}>
+      <TagName
+        className="score-feature-name"
+        {...(mdnUrl && {
+          href: `https://developer.mozilla.org${mdnUrl}`,
+          target: '_blank',
+          rel: 'norefferer',
+        })}>
         {entity.name}
       </TagName>
       {showComma && ', '}
       {/* <p className="score-feature-summary" dangerouslySetInnerHTML={{ __html: get(entity, 'mdn.summary') }} /> */}
     </div>
-  )
+  );
 };
-
 const Score = ({ response, survey }, { intl }) => {
   const containerRef = useRef(null);
   const [showConfetti, setShowConfetti] = useState(false);


### PR DESCRIPTION
- Currently, in the list of features to learn, if the entity does not have an MDN page, then it is simply ignored, resulting in outputs an extra comma, as shown in the screenshot:

![2020-10-25_12-26](https://user-images.githubusercontent.com/4408379/97103607-95567280-16be-11eb-9031-106aec586b31.png)

I suggest displaying all unknown fields to avoid this display error, especially since even if the feature is not described in MDN, this does not mean that it does not need to be shown, people can find out about it via Google, for example. MDN is just a shortcut, it shouldn't be required to display item. So proper output will look like this:

![2020-10-25_12-27](https://user-images.githubusercontent.com/4408379/97103641-c8006b00-16be-11eb-84ae-0ae95a7b00cf.png)


- In addition, if a person scored 100%, then there will be no unknown fields for they, which means we do not need to render the `Features` component at all.

- After that, MDN links open in new tabs.

- I also added a period at list the end.