### PR TITLE
Allow section nav item to wrap

### DIFF
--- a/packages/stateofjs/lib/stylesheets/_surveys.scss
+++ b/packages/stateofjs/lib/stylesheets/_surveys.scss
@@ -109,7 +109,6 @@
   }
   a {
     @include font-regular;
-    white-space: nowrap;
   }
   .active {
     @include font-bold;


### PR DESCRIPTION
To avoid issues like this:

![image](https://user-images.githubusercontent.com/4408379/101276123-027c1e00-37bc-11eb-898e-14be0b5eaa65.png)

cc @SachaG 