### PR TITLE
Increase contrast & add hidden button labels

### DIFF
--- a/packages/stateofjs/lib/components/survey/questions/FormSubmit.jsx
+++ b/packages/stateofjs/lib/components/survey/questions/FormSubmit.jsx
@@ -52,7 +52,8 @@ const FormSubmit = (
               history.push(getSurveyPath({ survey, response, number: sectionNumber + 1 }));
             }}
           >
-            <Components.FormattedMessage id={`sections.${nextSection.id}.title`} /> »
+            <span className="sr-only"><Components.FormattedMessage id="general.next_section" /></span>
+            <Components.FormattedMessage id={`sections.${nextSection.id}.title`} /> <span aria-hidden>»</span>
           </Components.LoadingButton>
         ) : readOnly ? null : (
           <Components.LoadingButton
@@ -87,7 +88,8 @@ const FormSubmit = (
               history.push(getSurveyPath({ survey, response, number: sectionNumber - 1 }));
             }}
           >
-            « <Components.FormattedMessage id={`sections.${previousSection.id}.title`} />
+            <span className="sr-only"><Components.FormattedMessage id="general.previous_section" /></span>
+            <span aria-hidden>«</span> <Components.FormattedMessage id={`sections.${previousSection.id}.title`} />
           </Components.LoadingButton>
         ) : (
           <div className="prev-placeholder" />

--- a/packages/stateofjs/lib/stylesheets/_global.scss
+++ b/packages/stateofjs/lib/stylesheets/_global.scss
@@ -12,6 +12,13 @@ html {
   box-sizing: inherit;
 }
 
+::selection {
+  background: $text-color;
+  background: var(--text-color);
+  color: $bg-color;
+  color: var(--bg-color);
+}
+
 body {
   background: $bg-color;
   background: var(--bg-color);

--- a/packages/stateofjs/lib/surveys/js/css2021outline.js
+++ b/packages/stateofjs/lib/surveys/js/css2021outline.js
@@ -14,7 +14,7 @@ export default {
   "imageUrl": "stateofcss2021.png",
   "bgColor": "#232840",
   "textColor": "#9ac6c9",
-  "linkColor": "#f649a7",
+  "linkColor": "#F95DB2",
   "hoverColor": "#59df7f",
   "credits": [
     {

--- a/packages/stateofjs/lib/surveys/yml/css2021outline.yml
+++ b/packages/stateofjs/lib/surveys/yml/css2021outline.yml
@@ -20,7 +20,7 @@ status: 2 # preview/open/closed
 imageUrl: 'stateofcss2021.png'
 bgColor: '#232840'
 textColor: '#9ac6c9'
-linkColor: '#f649a7'
+linkColor: '#F95DB2'
 hoverColor: '#59df7f'
 credits:
   - id: sarah_fossheim


### PR DESCRIPTION
- Change pink in the config for css 2021 to the new pink with increased contrast
- Increase contrast of selected text (invert bg and text color)
- Add invisible 'previous section' and 'next section' labels to the previous/next buttons in the footer navigation. Eg: `Previous page: Resources`, `Next Page: About you`. 

Relies on: https://github.com/StateOfJS/locale-en-US/pull/7