### PR TITLE
Center align translators block

### DIFF
--- a/packages/stateofjs/lib/stylesheets/_translators.scss
+++ b/packages/stateofjs/lib/stylesheets/_translators.scss
@@ -1,6 +1,7 @@
 
 .translators {
   max-width: 900px;
+  margin: 0 auto;
   padding: $spacing * 2;
   @include border2;
   @include border-radius;


### PR DESCRIPTION
it was probable removed by mistake in this commit - https://github.com/StateOfJS/StateOfJS-Vulcan/commit/fa4ca3d976c60740469da083f3cb3eae02a6df9b#diff-830153b927ea4cc2b3ce4de4026659e9ceed33137d91b84bf4288a618233ed46

cc @SachaG 
