### PR TITLE
Make check input labels clickable

### DIFF
--- a/packages/stateofjs/lib/stylesheets/_forms.scss
+++ b/packages/stateofjs/lib/stylesheets/_forms.scss
@@ -83,6 +83,7 @@
   .form-check-label {
     flex: 1;
     padding: $spacing/1.5 0;
+    cursor: pointer;
   }
   .form-item-contents {
     display: flex;


### PR DESCRIPTION
Currently it's pretty weird that radio/checkbox input doesn't change user cursor when you hover over it.

cc @SachaG 