### PR TITLE
fix: moving from cipher to hash

### DIFF
--- a/packages/stateofjs/lib/server/normalization/helpers.js
+++ b/packages/stateofjs/lib/server/normalization/helpers.js
@@ -7,20 +7,17 @@ import sortBy from 'lodash/sortBy';
 
 /*
 
-Encrypt text
+Creating Hash from Emails
 
 */
-const encryptionKey = process.env.ENCRYPTION_KEY || getSetting('encriptionKey');
-export const encrypt = (text) => {
-  const cipher = crypto.createCipheriv(
-    'aes-256-cbc',
-    Buffer.from(encryptionKey),
-    'stateofjsstateof'
-  );
-  let encrypted = cipher.update(text);
-  encrypted = Buffer.concat([encrypted, cipher.final()]);
-
-  return encrypted.toString('hex');
+const hashSalt = Buffer.from(
+  process.env.HASH_SALT || getSetting('hashSalt') || process.env.ENCRYPTION_KEY || getSetting('encriptionKey')
+);
+export const createHash = text => {
+  const hash = crypto.createHash('sha512-256WithRSAEncryption')
+  hash.update(hashSalt);
+  hash.update(text);
+  return hash.digest('hex');
 };
 
 /*

--- a/packages/stateofjs/lib/server/normalization/normalize.js
+++ b/packages/stateofjs/lib/server/normalization/normalize.js
@@ -1,6 +1,6 @@
 import countries from './countries';
 import {
-  encrypt,
+  createHash,
   cleanupValue,
   normalize,
   normalizeSource,
@@ -102,7 +102,7 @@ export const normalizeResponse = async ({
     
     */
     if (response.email) {
-      set(normResp, 'user_info.hash', encrypt(response.email));
+      set(normResp, 'user_info.hash', createHash(response.email));
     }
 
     /*
@@ -280,7 +280,7 @@ export const normalizeResponse = async ({
         info.user_info.email = response.email;
       }
       PrivateResponses.upsert({ responseId: response._id }, info);
-      set(normResp, 'user_info.hash', encrypt(response.email));
+      set(normResp, 'user_info.hash', createHash(response.email));
     }
 
     // console.log(JSON.stringify(normResp, '', 2));

--- a/packages/stateofjs/lib/server/scripts.js
+++ b/packages/stateofjs/lib/server/scripts.js
@@ -2,7 +2,7 @@ import Responses from '../modules/responses/collection';
 import NormalizedResponses from '../modules/normalized_responses/collection';
 import surveys from '../surveys';
 import { normalizeResponse } from './normalization/normalize';
-import { getEntities, encrypt } from './normalization/helpers';
+import { getEntities, createHash } from './normalization/helpers';
 import { logToFile } from 'meteor/vulcan:core';
 // import Users from 'meteor/vulcan:users';
 import {
@@ -347,7 +347,7 @@ export const generateEmailHash = async () => {
     if (i % 100 === 0) {
       console.log(`// Generated ${i}/${count} email hashes…`);
     }
-    const hash = encrypt(response.user_info.email);
+    const hash = createHash(response.user_info.email);
     NormalizedResponses.update(
       { _id: response._id },
       { $set: { 'user_info.hash': hash } }


### PR DESCRIPTION
Not having metor up and running (sorry 😅) I am not really in a position to test this properly, however this PR should replace the current encryption method with a hash of the email addresses. It reuses the previous Encryption Key as a hash salt, though I recommend renaming that property. If no hash/key property is set the code will fail, preventing the accidental start of the server without a salt set.